### PR TITLE
fix: GitHub Actions CIビルドエラーを修正

### DIFF
--- a/src/components/keyboard/Key.tsx
+++ b/src/components/keyboard/Key.tsx
@@ -71,10 +71,6 @@ export function Key({
     return () => observer.disconnect()
   }, [])
   
-  // Calculate clip-path for ISO Enter key (reverse L shape)
-  const notchRatio = shape === 'iso-enter' && upperWidth && lowerWidth
-    ? (lowerWidth / upperWidth) * 100
-    : 83.33
 
   const handleClick = () => {
     if (!disabled && onClick) {
@@ -115,11 +111,13 @@ export function Key({
       }}
     >
       {/* SVG border and background for ISO Enter key */}
-      {shape === 'iso-enter' && (
+      {shape === 'iso-enter' && upperWidth && lowerWidth && (
         <svg
           className="absolute inset-0 pointer-events-none"
           style={{ width: keyWidth, height: keyHeight }}
           viewBox={`0 0 ${keyWidth} ${keyHeight}`}
+          role="presentation"
+          aria-hidden="true"
         >
           {/* Background fill */}
           <path


### PR DESCRIPTION
## 概要
GitHub ActionsでのTypeScriptビルドエラーとBiomeのリントエラーを修正しました。

## 問題
Dependabotによる依存関係更新後、GitHub PagesへのデプロイCIが失敗していました。
- TypeScript: `upperWidth`と`lowerWidth`がundefinedの可能性がある
- TypeScript: 未使用の`notchRatio`変数
- Biome: SVGに代替テキストがない

## 修正内容
- ISO Enterキーのレンダリング条件に`upperWidth`と`lowerWidth`の存在チェックを追加
- 未使用の`notchRatio`変数を削除
- SVGに`role="presentation"`と`aria-hidden="true"`を追加

## テスト
- ✅ `npx tsc --noEmit` でTypeScriptエラーなし
- ✅ `npm run lint` でBiomeエラーなし
- ✅ `npm run build` でビルド成功

🤖 Generated with [Claude Code](https://claude.ai/code)