### PR TITLE
fix: mod-tap/layer-tap設定の表示とバリデーションを修正

### DIFF
--- a/src/components/LayerActionSelector.tsx
+++ b/src/components/LayerActionSelector.tsx
@@ -26,13 +26,47 @@ export function LayerActionSelector({ currentAction, onSave, onCancel }: LayerAc
   const { layerConfiguration, getLayerDisplayNumber } = useLayerStore()
 
   const handleSave = () => {
+    // Validation
+    if (actionType === 'simple' && tapKey === 'none') {
+      alert('Please select a key for the simple mapping')
+      return
+    }
+    if (actionType === 'mod-tap') {
+      if (tapKey === 'none') {
+        alert('Please select a tap key for the mod-tap')
+        return
+      }
+      if (holdModifiers.length === 0) {
+        alert('Please select at least one modifier for the mod-tap')
+        return
+      }
+    }
+    if (actionType === 'layer-tap') {
+      if (tapKey === 'none') {
+        alert('Please select a tap key for the layer-tap')
+        return
+      }
+      if (!holdLayer) {
+        alert('Please select a layer for the layer-tap')
+        return
+      }
+    }
+    if (actionType === 'layer-momentary' && !holdLayer) {
+      alert('Please select a layer for the momentary layer')
+      return
+    }
+    if (actionType === 'layer-toggle' && !tapLayer) {
+      alert('Please select a layer to toggle')
+      return
+    }
+
     const action: LayerAction = {
       type: actionType,
       tap:
         actionType !== 'layer-momentary'
           ? actionType === 'layer-toggle'
             ? { type: 'layer', layer: tapLayer }
-            : { type: 'key', key: tapKey === 'none' ? '' : tapKey }
+            : { type: 'key', key: tapKey }
           : undefined,
       hold:
         actionType !== 'simple'

--- a/src/components/LayerVisualKeyboard.tsx
+++ b/src/components/LayerVisualKeyboard.tsx
@@ -69,12 +69,16 @@ export function LayerVisualKeyboard({
 
     switch (action.type) {
       case 'simple':
-        return action.tap?.key || mapping.from
-      case 'mod-tap':
-        return `${action.tap?.key || '?'}/${action.hold?.modifiers?.join('+') || '?'}`
+        return action.tap?.key || '(unmapped)'
+      case 'mod-tap': {
+        const tapKey = action.tap?.key || '(no key)'
+        const modifiers = action.hold?.modifiers?.join('+') || '(no mods)'
+        return `${tapKey}/${modifiers}`
+      }
       case 'layer-tap': {
+        const tapKey = action.tap?.key || '(no key)'
         const layerNum = action.hold?.layer ? getLayerDisplayNumber(action.hold.layer) : '?'
-        return `${action.tap?.key || '?'}/L${layerNum}`
+        return `${tapKey}/L${layerNum}`
       }
       case 'layer-momentary': {
         const layerId = action.hold?.layer ?? action.tap?.layer
@@ -87,7 +91,7 @@ export function LayerVisualKeyboard({
         return `TG(${layerNum})`
       }
       default:
-        return mapping.from
+        return '(invalid)'
     }
   }
 

--- a/src/components/LayerVisualKeyboard.tsx
+++ b/src/components/LayerVisualKeyboard.tsx
@@ -29,15 +29,6 @@ export function LayerVisualKeyboard({
   const layer = layerConfiguration.layers.find(l => l.id === layerId)
   if (!layer) return null
 
-  // Convert layer mappings to simple modifications format for visualization
-  const simpleModifications: SimpleModification[] = layer.mappings.map(mapping => {
-    const toKeyCode = getKeyCodeFromMapping(mapping)
-    return {
-      from: { key_code: mapping.from },
-      to: [{ key_code: toKeyCode }]
-    }
-  })
-
   const handleKeyClick = (keyCode: string) => {
     console.log('Key clicked:', keyCode)
     setSelectedKey(keyCode)
@@ -64,36 +55,52 @@ export function LayerVisualKeyboard({
     onMappingChange?.()
   }
 
-  const getKeyCodeFromMapping = (mapping: LayerMapping): string => {
+  // Create SimpleModifications for ALL mappings with appropriate display labels
+  const simpleModifications: SimpleModification[] = layer.mappings.map(mapping => {
     const action = mapping.action
+    let toKeyCode = ''
 
+    // Determine what to display as the mapped key
     switch (action.type) {
       case 'simple':
-        return action.tap?.key || '(unmapped)'
+        toKeyCode = action.tap?.key || mapping.from
+        break
       case 'mod-tap': {
-        const tapKey = action.tap?.key || '(no key)'
-        const modifiers = action.hold?.modifiers?.join('+') || '(no mods)'
-        return `${tapKey}/${modifiers}`
+        const tapKey = action.tap?.key || '?'
+        const modifiers =
+          action.hold?.modifiers
+            ?.map(m => m.replace('left_', '').replace('right_', '').charAt(0).toUpperCase())
+            .join('') || '?'
+        toKeyCode = `${tapKey}/${modifiers}`
+        break
       }
       case 'layer-tap': {
-        const tapKey = action.tap?.key || '(no key)'
+        const tapKey = action.tap?.key || '?'
         const layerNum = action.hold?.layer ? getLayerDisplayNumber(action.hold.layer) : '?'
-        return `${tapKey}/L${layerNum}`
+        toKeyCode = `${tapKey}/L${layerNum}`
+        break
       }
       case 'layer-momentary': {
         const layerId = action.hold?.layer ?? action.tap?.layer
         const layerNum = layerId ? getLayerDisplayNumber(layerId) : '?'
-        return `MO(${layerNum})`
+        toKeyCode = `MO(${layerNum})`
+        break
       }
       case 'layer-toggle': {
         const layerId = action.tap?.layer ?? action.hold?.layer
         const layerNum = layerId ? getLayerDisplayNumber(layerId) : '?'
-        return `TG(${layerNum})`
+        toKeyCode = `TG(${layerNum})`
+        break
       }
       default:
-        return '(invalid)'
+        toKeyCode = mapping.from
     }
-  }
+
+    return {
+      from: { key_code: mapping.from },
+      to: [{ key_code: toKeyCode }]
+    }
+  })
 
   return (
     <>

--- a/src/lib/layerGenerator.ts
+++ b/src/lib/layerGenerator.ts
@@ -101,30 +101,38 @@ function generateManipulatorsForMapping(mapping: LayerMapping): Manipulator[] {
 
   switch (action.type) {
     case 'simple':
-      // Simple key remapping
-      if (action.tap) {
+      // Simple key remapping - skip if no valid key
+      if (action.tap?.key) {
         manipulators.push(generateSimpleManipulator(mapping.from, action.tap))
       }
       break
 
     case 'mod-tap':
-      // Tap for key, hold for modifier
-      manipulators.push(generateModTapManipulator(mapping.from, action))
+      // Tap for key, hold for modifier - skip if no valid tap key
+      if (action.tap?.key && action.hold?.modifiers?.length) {
+        manipulators.push(generateModTapManipulator(mapping.from, action))
+      }
       break
 
     case 'layer-tap':
-      // Tap for key, hold for layer
-      manipulators.push(generateLayerTapManipulator(mapping.from, action))
+      // Tap for key, hold for layer - skip if no valid tap key or layer
+      if (action.tap?.key && action.hold?.layer) {
+        manipulators.push(generateLayerTapManipulator(mapping.from, action))
+      }
       break
 
     case 'layer-momentary':
-      // Hold to activate layer temporarily
-      manipulators.push(generateLayerMomentaryManipulator(mapping.from, action))
+      // Hold to activate layer temporarily - skip if no valid layer
+      if (action.hold?.layer || action.tap?.layer) {
+        manipulators.push(generateLayerMomentaryManipulator(mapping.from, action))
+      }
       break
 
     case 'layer-toggle':
-      // Toggle layer on/off
-      manipulators.push(generateLayerToggleManipulator(mapping.from, action))
+      // Toggle layer on/off - skip if no valid layer
+      if (action.tap?.layer || action.hold?.layer) {
+        manipulators.push(generateLayerToggleManipulator(mapping.from, action))
+      }
       break
   }
 


### PR DESCRIPTION
## 概要
mod-tap/layer-tap機能でバリデーションエラーと表示の問題を修正しました。

## 修正内容

### 1. バリデーション強化
- tapキーが未選択（none）の場合は保存できないように修正
- mod-tapでモディファイアが未選択の場合も保存を防止
- layer-tap/momentary/toggleでレイヤーが未選択の場合も同様にバリデーション

### 2. 表示エラーの修正
- LayerVisualKeyboardでmod-tap/layer-tapマッピングが正しく表示されない問題を修正
- VisualKeyboardコンポーネントに無効なkey_codeが渡されることを防止
- 複雑なマッピング（mod-tap、layer-tap等）の表示を適切に実装

### 3. UI改善
- モディファイアキーの短縮表示（例：left_control → C）
- エラー時の分かりやすいメッセージ表示
- 不正な状態のマッピングは「?」で表示

## テスト項目
- [x] mod-tapで必須フィールド未入力時にアラート表示
- [x] layer-tapで必須フィールド未入力時にアラート表示
- [x] 正しく設定したmod-tapがビジュアルキーボードに表示される
- [x] 正しく設定したlayer-tapがビジュアルキーボードに表示される
- [x] エクスポート時に不正なマッピングがスキップされる

## スクリーンショット
mod-tap設定（a/C）が正しくビジュアルキーボードに表示されるようになりました。

🤖 Generated with [Claude Code](https://claude.ai/code)