### PR TITLE
Manipulator型にdescriptionフィールドを追加

### DIFF
--- a/src/types/karabiner-schema.ts
+++ b/src/types/karabiner-schema.ts
@@ -189,6 +189,7 @@ const ManipulatorParametersSchema = z.object({
 
 const ManipulatorSchema = z.object({
   type: z.enum(['basic', 'mouse_motion_to_scroll']),
+  description: z.string().optional(),
   from: FromEventSchema,
   to: z.array(ToEventSchema).optional(),
   to_if_alone: z.array(ToEventSchema).optional(),

--- a/src/types/karabiner.ts
+++ b/src/types/karabiner.ts
@@ -147,6 +147,7 @@ export interface Rule {
 
 export interface Manipulator {
   type: 'basic' | 'mouse_motion_to_scroll'
+  description?: string
   from: FromEvent
   to?: ToEvent[]
   to_if_alone?: ToEvent[]


### PR DESCRIPTION
## 概要
- Karabiner設定のインポート/エクスポート時にmanipulatorレベルのdescriptionが失われる問題を修正
- `Manipulator`型と`ManipulatorSchema`に`description`フィールドを追加

## 背景
Karabiner-Elementsの実際の設定ファイルでは、Complex Modificationsのmanipulatorレベルで`description`フィールドがサポートされていますが、Slingの型定義ではこのフィールドが欠けていました。

これにより、既存のKarabiner設定をSlingに読み込んでから再エクスポートすると、manipulatorの説明が消えてしまう問題が発生していました。

## 変更内容
- `src/types/karabiner.ts`: `Manipulator`インターフェースに`description?: string`を追加
- `src/types/karabiner-schema.ts`: `ManipulatorSchema`に`description: z.string().optional()`を追加

## テスト方法
1. manipulatorレベルのdescriptionを含むKarabiner設定をインポート
2. 設定をエクスポート
3. エクスポートされたファイルにdescriptionが保持されていることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)